### PR TITLE
Add theforeman gem and Rubocop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,9 @@ inherit_gem:
   theforeman-rubocop:
     - default.yml
 
+AllCops:
+  TargetRubyVersion: 2.7
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,18 @@
+inherit_gem:
+  theforeman-rubocop:
+    - default.yml
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/SymbolProc:
+  Enabled: false
+
+Layout/LineLength:
+  Enabled: false
+
+Style/RedundantSelf:
+  Enabled: false
+
+Style/ExpandPathArguments:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gemspec
 
@@ -7,6 +7,8 @@ gem 'gettext', '>= 3.1.3', '< 4.0.0'
 group :test do
   gem 'rake'
 end
+
+gem 'theforeman-rubocop', '~> 0.1.0'
 
 # load local gemfile
 local_gemfile = File.join(File.dirname(__FILE__), 'Gemfile.local')

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-require "hammer_cli_foreman_rh_cloud/version"
-require "hammer_cli_foreman_rh_cloud/i18n"
-require "hammer_cli/i18n/find_task"
+require 'hammer_cli_foreman_rh_cloud/version'
+require 'hammer_cli_foreman_rh_cloud/i18n'
+require 'hammer_cli/i18n/find_task'
 HammerCLI::I18n::FindTask.define(HammerCLIForemanRhCloud::I18n::LocaleDomain.new, HammerCLIForemanRhCloud.version.to_s)

--- a/hammer_cli_foreman_rh_cloud.gemspec
+++ b/hammer_cli_foreman_rh_cloud.gemspec
@@ -18,4 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir['{test}/**/*']
 
   spec.add_dependency 'hammer_cli_foreman', '>= 3.0.0', '< 4.0.0'
+
+  s.required_ruby_version = '>= 2.7', '< 4'
 end

--- a/hammer_cli_foreman_rh_cloud.gemspec
+++ b/hammer_cli_foreman_rh_cloud.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.platform      = Gem::Platform::RUBY
   spec.summary       = 'Foreman Rh Cloud plugin for Hammer CLI'
 
-  spec.files         = Dir['{lib,config}/**/*', 'LICENSE', 'README*'] + Dir["locale/**/*.{po,pot,mo}"]
+  spec.files         = Dir['{lib,config}/**/*', 'LICENSE', 'README*'] + Dir['locale/**/*.{po,pot,mo}']
   spec.require_paths = ['lib']
   spec.test_files    = Dir['{test}/**/*']
 


### PR DESCRIPTION
Added theforeman-rubocop gem to v0.1.0 and the rubocop configuration, followed by default style from the gem.

default.yml: https://github.com/theforeman/theforeman-rubocop/?tab=readme-ov-file#basic-style---default-performance-and-rails-cops

This is part of Rubocop standerdization, link for the reference: https://community.theforeman.org/t/standardizing-rubocop-with-theforeman-rubocop/37239


https://github.com/theforeman/hammer-cli-foreman-rh-cloud/pull/5