### PR TITLE
Use the correct variable in required_ruby_version

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -15,11 +15,4 @@ jobs:
     name: Rubocop
     uses: theforeman/actions/.github/workflows/rubocop.yml@v0
     with:
-        command: bundle exec rubocop --parallel --format github
-
-  test:
-    name: Tests
-    needs: rubocop
-    uses: theforeman/actions/.github/workflows/test-gem.yml@v0
-    with:
-      command: bundle exec rake test
+      command: bundle exec rubocop --parallel --format github

--- a/hammer_cli_foreman_rh_cloud.gemspec
+++ b/hammer_cli_foreman_rh_cloud.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'hammer_cli_foreman', '>= 3.0.0', '< 4.0.0'
 
-  s.required_ruby_version = '>= 2.7', '< 4'
+  spec.required_ruby_version = '>= 2.7', '< 4'
 end


### PR DESCRIPTION
The variable `s` doesn't exist and needs to be `spec`. This slipped by because there was no CI set up in the repository.

Fixes: a1ffa5f46182 ("Add ruby support '>= 2.7', '< 4'")