### PR TITLE
i18n - extracting new, pulling from tx

### DIFF
--- a/locale/bn/hammer_cli_foreman_rh_cloud.po
+++ b/locale/bn/hammer_cli_foreman_rh_cloud.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Bengali (https://app.transifex.com/foreman/teams/114/bn/)\n"
 "MIME-Version: 1.0\n"
@@ -17,32 +15,40 @@ msgstr ""
 "Language: bn\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/bn_IN/hammer_cli_foreman_rh_cloud.po
+++ b/locale/bn_IN/hammer_cli_foreman_rh_cloud.po
@@ -3,47 +3,53 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Language-Team: Bengali (India) (https://app.transifex.com/foreman/teams/114/"
-"bn_IN/)\n"
+"Language-Team: Bengali (India) (https://app.transifex.com/foreman/teams/114/bn"
+"_IN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: bn_IN\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/bqi/hammer_cli_foreman_rh_cloud.po
+++ b/locale/bqi/hammer_cli_foreman_rh_cloud.po
@@ -3,47 +3,53 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Language-Team: Luri (Bakhtiari) (https://app.transifex.com/foreman/teams/114/"
-"bqi/)\n"
+"Language-Team: Luri (Bakhtiari) (https://app.transifex.com/foreman/teams/114/b"
+"qi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: bqi\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/ca/hammer_cli_foreman_rh_cloud.po
+++ b/locale/ca/hammer_cli_foreman_rh_cloud.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Catalan (https://app.transifex.com/foreman/teams/114/ca/)\n"
 "MIME-Version: 1.0\n"
@@ -17,32 +15,40 @@ msgstr ""
 "Language: ca\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/cs_CZ/hammer_cli_foreman_rh_cloud.po
+++ b/locale/cs_CZ/hammer_cli_foreman_rh_cloud.po
@@ -6,49 +6,55 @@
 # Translators:
 # Pavel Borecki <pavel.borecki@gmail.com>, 2023
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>, 2023\n"
-"Language-Team: Czech (Czech Republic) (https://app.transifex.com/foreman/"
-"teams/114/cs_CZ/)\n"
+"Language-Team: Czech (Czech Republic) (https://app.transifex.com/foreman/teams"
+"/114/cs_CZ/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: cs_CZ\n"
-"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n "
-"<= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n <= "
+"4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
-msgstr "Identifikátor úlohy"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
+msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr "Identifikátor úlohy"
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/de/hammer_cli_foreman_rh_cloud.po
+++ b/locale/de/hammer_cli_foreman_rh_cloud.po
@@ -6,12 +6,10 @@
 # Translators:
 # Ettore Atalan <atalanttore@googlemail.com>, 2023
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Last-Translator: Ettore Atalan <atalanttore@googlemail.com>, 2023\n"
 "Language-Team: German (https://app.transifex.com/foreman/teams/114/de/)\n"
@@ -21,32 +19,40 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
-msgstr "Aufgabenkennung"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
+msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr "Aufgabenkennung"
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/de_AT/hammer_cli_foreman_rh_cloud.po
+++ b/locale/de_AT/hammer_cli_foreman_rh_cloud.po
@@ -3,47 +3,53 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Language-Team: German (Austria) (https://app.transifex.com/foreman/teams/114/"
-"de_AT/)\n"
+"Language-Team: German (Austria) (https://app.transifex.com/foreman/teams/114/d"
+"e_AT/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: de_AT\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/de_DE/hammer_cli_foreman_rh_cloud.po
+++ b/locale/de_DE/hammer_cli_foreman_rh_cloud.po
@@ -3,47 +3,53 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Language-Team: German (Germany) (https://app.transifex.com/foreman/teams/114/"
-"de_DE/)\n"
+"Language-Team: German (Germany) (https://app.transifex.com/foreman/teams/114/d"
+"e_DE/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: de_DE\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/el/hammer_cli_foreman_rh_cloud.po
+++ b/locale/el/hammer_cli_foreman_rh_cloud.po
@@ -6,12 +6,10 @@
 # Translators:
 # Efstathios Iosifidis <iefstathios@gmail.com>, 2023
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Last-Translator: Efstathios Iosifidis <iefstathios@gmail.com>, 2023\n"
 "Language-Team: Greek (https://app.transifex.com/foreman/teams/114/el/)\n"
@@ -21,32 +19,40 @@ msgstr ""
 "Language: el\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
-msgstr "ID εργασίας"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
+msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr "ID εργασίας"
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/en/hammer_cli_foreman_rh_cloud.po
+++ b/locale/en/hammer_cli_foreman_rh_cloud.po
@@ -7,7 +7,6 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-07-12 16:17+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,32 +16,40 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/en_GB/hammer_cli_foreman_rh_cloud.po
+++ b/locale/en_GB/hammer_cli_foreman_rh_cloud.po
@@ -6,54 +6,56 @@
 # Translators:
 # Andi Chandler <andi@gowling.com>, 2024
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Last-Translator: Andi Chandler <andi@gowling.com>, 2024\n"
-"Language-Team: English (United Kingdom) (https://app.transifex.com/foreman/"
-"teams/114/en_GB/)\n"
+"Language-Team: English (United Kingdom) (https://app.transifex.com/foreman/tea"
+"ms/114/en_GB/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
-msgstr "Cloud connector enable task started"
-
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Duration: %sms"
 msgstr ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
 
-msgid "Task id"
-msgstr "Task id"
+msgid "Message: %s"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
+msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr "Inventory sync task started successfully"
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
 msgstr ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+
+msgid "Task id"
+msgstr "Task id"
+
+msgid "Path to download report."
+msgstr ""
 
 msgid "Failed to download report"
 msgstr "Failed to download report"
+
+msgid "Generate the report, but do not upload"
+msgstr ""
 
 msgid "Report generation started successfully"
 msgstr "Report generation started successfully"
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."

--- a/locale/en_US/hammer_cli_foreman_rh_cloud.po
+++ b/locale/en_US/hammer_cli_foreman_rh_cloud.po
@@ -3,47 +3,53 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Language-Team: English (United States) (https://app.transifex.com/foreman/"
-"teams/114/en_US/)\n"
+"Language-Team: English (United States) (https://app.transifex.com/foreman/team"
+"s/114/en_US/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: en_US\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/es/hammer_cli_foreman_rh_cloud.po
+++ b/locale/es/hammer_cli_foreman_rh_cloud.po
@@ -6,12 +6,10 @@
 # Translators:
 # Amit Upadhye <aupadhye@redhat.com>, 2023
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Last-Translator: Amit Upadhye <aupadhye@redhat.com>, 2023\n"
 "Language-Team: Spanish (https://app.transifex.com/foreman/teams/114/es/)\n"
@@ -19,35 +17,43 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: es\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
-"1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 :"
+" 2;\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
-msgstr "Id de tarea"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
+msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr "Id de tarea"
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/et_EE/hammer_cli_foreman_rh_cloud.po
+++ b/locale/et_EE/hammer_cli_foreman_rh_cloud.po
@@ -3,47 +3,53 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Language-Team: Estonian (Estonia) (https://app.transifex.com/foreman/"
-"teams/114/et_EE/)\n"
+"Language-Team: Estonian (Estonia) (https://app.transifex.com/foreman/teams/114"
+"/et_EE/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: et_EE\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/fr/hammer_cli_foreman_rh_cloud.po
+++ b/locale/fr/hammer_cli_foreman_rh_cloud.po
@@ -7,55 +7,59 @@
 # Amit Upadhye <aupadhye@redhat.com>, 2023
 # Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarden.nl>, 2024
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Last-Translator: Ewoud Kohl van Wijngaarden <ewoud"
-"+transifex@kohlvanwijngaarden.nl>, 2024\n"
+"Last-Translator: Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarde"
+"n.nl>, 2024\n"
 "Language-Team: French (https://app.transifex.com/foreman/teams/114/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: fr\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
-"1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 100000"
+"0 == 0 ? 1 : 2;\n"
 
-msgid "Cloud connector enable task started"
-msgstr "La tâche d'activation du connecteur cloud a démarré"
-
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Duration: %sms"
 msgstr ""
-"Impossible d'activer le connecteur cloud, veuillez vérifier les journaux du "
-"serveur pour plus d'informations"
 
-msgid "Task id"
-msgstr "Id tâche"
+msgid "Message: %s"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
+msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr "La tâche de synchronisation de l'inventaire a démarré avec succès"
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
 msgstr ""
-"Impossible de démarrer la tâche de synchronisation de l'inventaire, veuillez "
-"vérifier les journaux du serveur pour plus d'informations"
+"Impossible de démarrer la tâche de synchronisation de l'inventaire, veuillez v"
+"érifier les journaux du serveur pour plus d'informations"
+
+msgid "Task id"
+msgstr "Id tâche"
+
+msgid "Path to download report."
+msgstr ""
 
 msgid "Failed to download report"
 msgstr "Le téléchargement du module   a échoué."
+
+msgid "Generate the report, but do not upload"
+msgstr ""
 
 msgid "Report generation started successfully"
 msgstr "La génération du rapport a démarré avec succès"
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""
-"Impossible de démarrer la tâche de synchronisation de l'inventaire, veuillez "
-"vérifier les journaux du serveur pour plus d'informations"
+"Impossible de démarrer la tâche de synchronisation de l'inventaire, veuillez v"
+"érifier les journaux du serveur pour plus d'informations"

--- a/locale/gl/hammer_cli_foreman_rh_cloud.po
+++ b/locale/gl/hammer_cli_foreman_rh_cloud.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Galician (https://app.transifex.com/foreman/teams/114/gl/)\n"
 "MIME-Version: 1.0\n"
@@ -17,32 +15,40 @@ msgstr ""
 "Language: gl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/gu/hammer_cli_foreman_rh_cloud.po
+++ b/locale/gu/hammer_cli_foreman_rh_cloud.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Gujarati (https://app.transifex.com/foreman/teams/114/gu/)\n"
 "MIME-Version: 1.0\n"
@@ -17,32 +15,40 @@ msgstr ""
 "Language: gu\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/hammer_cli_foreman_rh_cloud.pot
+++ b/locale/hammer_cli_foreman_rh_cloud.pot
@@ -1,15 +1,15 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
+# This file is distributed under the same license as the hammer_cli_foreman_rh_cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: hammer-cli-foreman-rh-cloud 1.0.1\n"
+"Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.7\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
-"PO-Revision-Date: 2023-07-12 16:17+0000\n"
+"POT-Creation-Date: 2026-07-01 03:42-0400\n"
+"PO-Revision-Date: 2026-07-01 03:42-0400\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -18,41 +18,54 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../lib/hammer_cli_foreman_rh_cloud/cloud_connector.rb:11
-msgid "Cloud connector enable task started"
+#: ../lib/hammer_cli_foreman_rh_cloud/command_extensions/ping.rb:16
+msgid "Duration: %sms"
 msgstr ""
 
-#: ../lib/hammer_cli_foreman_rh_cloud/cloud_connector.rb:12
-msgid ""
-"Failed to enable cloud connector, please check server logs for more informatio"
-"n"
+#: ../lib/hammer_cli_foreman_rh_cloud/command_extensions/ping.rb:18
+msgid "Message: %s"
 msgstr ""
 
-#: ../lib/hammer_cli_foreman_rh_cloud/cloud_connector.rb:15
-#: ../lib/hammer_cli_foreman_rh_cloud/inventory.rb:15
-msgid "Task id"
+#: ../lib/hammer_cli_foreman_rh_cloud/command_extensions/ping.rb:28
+#: ../lib/hammer_cli_foreman_rh_cloud/command_extensions/ping.rb:34
+msgid "Status"
 msgstr ""
 
-#: ../lib/hammer_cli_foreman_rh_cloud/inventory.rb:11
-msgid "Inventory sync task started successfully"
+#: ../lib/hammer_cli_foreman_rh_cloud/command_extensions/ping.rb:29
+#: ../lib/hammer_cli_foreman_rh_cloud/command_extensions/ping.rb:35
+msgid "Server Response"
 msgstr ""
 
 #: ../lib/hammer_cli_foreman_rh_cloud/inventory.rb:12
-msgid ""
-"Failed to start inventory sync task, please check server logs for more informa"
-"tion"
+msgid "Inventory sync task started successfully"
 msgstr ""
 
-#: ../lib/hammer_cli_foreman_rh_cloud/report.rb:12
+#: ../lib/hammer_cli_foreman_rh_cloud/inventory.rb:13
+msgid ""
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_rh_cloud/inventory.rb:16
+msgid "Task id"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_rh_cloud/inventory.rb:29
+msgid "Path to download report."
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_rh_cloud/inventory.rb:33
 msgid "Failed to download report"
 msgstr ""
 
-#: ../lib/hammer_cli_foreman_rh_cloud/report.rb:22
+#: ../lib/hammer_cli_foreman_rh_cloud/inventory.rb:43
+msgid "Generate the report, but do not upload"
+msgstr ""
+
+#: ../lib/hammer_cli_foreman_rh_cloud/inventory.rb:44
 msgid "Report generation started successfully"
 msgstr ""
 
-#: ../lib/hammer_cli_foreman_rh_cloud/report.rb:23
+#: ../lib/hammer_cli_foreman_rh_cloud/inventory.rb:45
 msgid ""
-"Failed to start report generation task, please check server logs for more info"
-"rmation."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/he_IL/hammer_cli_foreman_rh_cloud.po
+++ b/locale/he_IL/hammer_cli_foreman_rh_cloud.po
@@ -3,48 +3,54 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Language-Team: Hebrew (Israel) (https://app.transifex.com/foreman/teams/114/"
-"he_IL/)\n"
+"Language-Team: Hebrew (Israel) (https://app.transifex.com/foreman/teams/114/he"
+"_IL/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: he_IL\n"
-"Plural-Forms: nplurals=3; plural=(n == 1 && n % 1 == 0) ? 0 : (n == 2 && n % "
-"1 == 0) ? 1: 2;\n"
+"Plural-Forms: nplurals=3; plural=(n == 1 && n % 1 == 0) ? 0 : (n == 2 && n % 1"
+" == 0) ? 1: 2;\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/hi/hammer_cli_foreman_rh_cloud.po
+++ b/locale/hi/hammer_cli_foreman_rh_cloud.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Hindi (https://app.transifex.com/foreman/teams/114/hi/)\n"
 "MIME-Version: 1.0\n"
@@ -17,32 +15,40 @@ msgstr ""
 "Language: hi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/id/hammer_cli_foreman_rh_cloud.po
+++ b/locale/id/hammer_cli_foreman_rh_cloud.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Indonesian (https://app.transifex.com/foreman/teams/114/id/)\n"
 "MIME-Version: 1.0\n"
@@ -17,32 +15,40 @@ msgstr ""
 "Language: id\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/it/hammer_cli_foreman_rh_cloud.po
+++ b/locale/it/hammer_cli_foreman_rh_cloud.po
@@ -3,47 +3,53 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Italian (https://app.transifex.com/foreman/teams/114/it/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: it\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
-"1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 :"
+" 2;\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/ja/hammer_cli_foreman_rh_cloud.po
+++ b/locale/ja/hammer_cli_foreman_rh_cloud.po
@@ -7,15 +7,13 @@
 # Bryan Kearney <bryan.kearney@gmail.com>, 2023
 # Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarden.nl>, 2024
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Last-Translator: Ewoud Kohl van Wijngaarden <ewoud"
-"+transifex@kohlvanwijngaarden.nl>, 2024\n"
+"Last-Translator: Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarde"
+"n.nl>, 2024\n"
 "Language-Team: Japanese (https://app.transifex.com/foreman/teams/114/ja/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,38 +21,40 @@ msgstr ""
 "Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "Cloud connector enable task started"
-msgstr "クラウドコネクター有効化タスクが開始しました"
-
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Duration: %sms"
 msgstr ""
-"クラウドコネクターを有効にできませんでした。詳細はサーバーログを確認してくだ"
-"さい"
 
-msgid "Task id"
-msgstr "タスク ID"
+msgid "Message: %s"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
+msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr "インベントリー同期タスクが正常に開始しました"
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr "インベントリー同期タスクを開始できませんでした。詳細はサーバーログを確認してください"
+
+msgid "Task id"
+msgstr "タスク ID"
+
+msgid "Path to download report."
 msgstr ""
-"インベントリー同期タスクを開始できませんでした。詳細はサーバーログを確認して"
-"ください"
 
 msgid "Failed to download report"
 msgstr "レポートのダウンロードに失敗しました"
+
+msgid "Generate the report, but do not upload"
+msgstr ""
 
 msgid "Report generation started successfully"
 msgstr "レポート生成が正常に開始しました"
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
-msgstr ""
-"レポート生成タスクを開始できませんでした。詳細はサーバーログを確認してくださ"
-"い。"
+"Failed to start report generation task, please check server logs for more information."
+msgstr "レポート生成タスクを開始できませんでした。詳細はサーバーログを確認してください。"

--- a/locale/ka/hammer_cli_foreman_rh_cloud.po
+++ b/locale/ka/hammer_cli_foreman_rh_cloud.po
@@ -6,12 +6,10 @@
 # Translators:
 # Temuri Doghonadze <temuri.doghonadze@gmail.com>, 2023
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>, 2023\n"
 "Language-Team: Georgian (https://app.transifex.com/foreman/teams/114/ka/)\n"
@@ -21,38 +19,44 @@ msgstr ""
 "Language: ka\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 
-msgid "Cloud connector enable task started"
-msgstr "Cloud connector-ის ჩართვის ამოცანა გაეშვა"
-
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Duration: %sms"
 msgstr ""
-"Cloud connector-ის ჩართვა ჩავარდა. მეტი ინფორმაციისთვის იხილეთ სერვერის "
-"ჟურნალი"
 
-msgid "Task id"
-msgstr "ამოცანის ID"
+msgid "Message: %s"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
+msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr "ინვენტარის სინქრონიზაცია წარმატებით დაიწყო"
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
 msgstr ""
-"ინვენტარის სინქრონიზაციის ამოცანის გაშვება ჩავარდა. მეტი ინფორმაციისთვის "
-"იხილეთ სერვერის ჟურნალი"
+"ინვენტარის სინქრონიზაციის ამოცანის გაშვება ჩავარდა. მეტი ინფორმაციისთვის იხილე"
+"თ სერვერის ჟურნალი"
+
+msgid "Task id"
+msgstr "ამოცანის ID"
+
+msgid "Path to download report."
+msgstr ""
 
 msgid "Failed to download report"
 msgstr "ანგარიშის გადმოწერა ჩავარდა"
+
+msgid "Generate the report, but do not upload"
+msgstr ""
 
 msgid "Report generation started successfully"
 msgstr "ანგარიშის გენერაცია წარმატებით გაეშვა"
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""
-"ანგარიშის გენერაციის ამოცანის გაშვება ჩავარდა. მეტი ინფორმაციისთვის იხილეთ "
-"სერვერის ჟურნალი."
+"ანგარიშის გენერაციის ამოცანის გაშვება ჩავარდა. მეტი ინფორმაციისთვის იხილეთ სერ"
+"ვერის ჟურნალი."

--- a/locale/kn/hammer_cli_foreman_rh_cloud.po
+++ b/locale/kn/hammer_cli_foreman_rh_cloud.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Kannada (https://app.transifex.com/foreman/teams/114/kn/)\n"
 "MIME-Version: 1.0\n"
@@ -17,32 +15,40 @@ msgstr ""
 "Language: kn\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/ko/hammer_cli_foreman_rh_cloud.po
+++ b/locale/ko/hammer_cli_foreman_rh_cloud.po
@@ -6,15 +6,13 @@
 # Translators:
 # Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarden.nl>, 2024
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Last-Translator: Ewoud Kohl van Wijngaarden <ewoud"
-"+transifex@kohlvanwijngaarden.nl>, 2024\n"
+"Last-Translator: Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarde"
+"n.nl>, 2024\n"
 "Language-Team: Korean (https://app.transifex.com/foreman/teams/114/ko/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,37 +20,40 @@ msgstr ""
 "Language: ko\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "Cloud connector enable task started"
-msgstr "클라우드 커넥터 활성화 작업이 시작되었습니다."
-
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Duration: %sms"
 msgstr ""
-"클라우드 커넥터를 활성화하는 데 실패했습니다. 자세한 내용은 서버 로그를 확인"
-"하세요."
 
-msgid "Task id"
-msgstr "작업 ID"
+msgid "Message: %s"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
+msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr "인벤토리 동기화 작업이 성공적으로 시작되었습니다."
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr "인벤토리 동기화 작업을 시작하지 못했습니다. 자세한 내용은 서버 로그를 확인하세요."
+
+msgid "Task id"
+msgstr "작업 ID"
+
+msgid "Path to download report."
 msgstr ""
-"인벤토리 동기화 작업을 시작하지 못했습니다. 자세한 내용은 서버 로그를 확인하"
-"세요."
 
 msgid "Failed to download report"
 msgstr "보고서를 다운로드하지 못했습니다."
+
+msgid "Generate the report, but do not upload"
+msgstr ""
 
 msgid "Report generation started successfully"
 msgstr "보고서 생성이 성공적으로 시작되었습니다."
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
-msgstr ""
-"보고서 생성 작업을 시작하지 못했습니다. 자세한 내용은 서버 로그를 확인하세요."
+"Failed to start report generation task, please check server logs for more information."
+msgstr "보고서 생성 작업을 시작하지 못했습니다. 자세한 내용은 서버 로그를 확인하세요."

--- a/locale/ml_IN/hammer_cli_foreman_rh_cloud.po
+++ b/locale/ml_IN/hammer_cli_foreman_rh_cloud.po
@@ -3,47 +3,53 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Language-Team: Malayalam (India) (https://app.transifex.com/foreman/"
-"teams/114/ml_IN/)\n"
+"Language-Team: Malayalam (India) (https://app.transifex.com/foreman/teams/114/"
+"ml_IN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ml_IN\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/mr/hammer_cli_foreman_rh_cloud.po
+++ b/locale/mr/hammer_cli_foreman_rh_cloud.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Marathi (https://app.transifex.com/foreman/teams/114/mr/)\n"
 "MIME-Version: 1.0\n"
@@ -17,32 +15,40 @@ msgstr ""
 "Language: mr\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/nl_NL/hammer_cli_foreman_rh_cloud.po
+++ b/locale/nl_NL/hammer_cli_foreman_rh_cloud.po
@@ -3,47 +3,53 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Language-Team: Dutch (Netherlands) (https://app.transifex.com/foreman/"
-"teams/114/nl_NL/)\n"
+"Language-Team: Dutch (Netherlands) (https://app.transifex.com/foreman/teams/11"
+"4/nl_NL/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: nl_NL\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/or/hammer_cli_foreman_rh_cloud.po
+++ b/locale/or/hammer_cli_foreman_rh_cloud.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Odia (https://app.transifex.com/foreman/teams/114/or/)\n"
 "MIME-Version: 1.0\n"
@@ -17,32 +15,40 @@ msgstr ""
 "Language: or\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/pa/hammer_cli_foreman_rh_cloud.po
+++ b/locale/pa/hammer_cli_foreman_rh_cloud.po
@@ -3,47 +3,53 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Language-Team: Panjabi (Punjabi) (https://app.transifex.com/foreman/"
-"teams/114/pa/)\n"
+"Language-Team: Panjabi (Punjabi) (https://app.transifex.com/foreman/teams/114/"
+"pa/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: pa\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/pl/hammer_cli_foreman_rh_cloud.po
+++ b/locale/pl/hammer_cli_foreman_rh_cloud.po
@@ -3,48 +3,54 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Polish (https://app.transifex.com/foreman/teams/114/pl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: pl\n"
-"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n"
-"%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n"
-"%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12"
+" || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n"
+"%100>=12 && n%100<=14) ? 2 : 3);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/pl_PL/hammer_cli_foreman_rh_cloud.po
+++ b/locale/pl_PL/hammer_cli_foreman_rh_cloud.po
@@ -3,49 +3,55 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Language-Team: Polish (Poland) (https://app.transifex.com/foreman/teams/114/"
-"pl_PL/)\n"
+"Language-Team: Polish (Poland) (https://app.transifex.com/foreman/teams/114/pl"
+"_PL/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: pl_PL\n"
-"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n"
-"%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n"
-"%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12"
+" || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n"
+"%100>=12 && n%100<=14) ? 2 : 3);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/pt/hammer_cli_foreman_rh_cloud.po
+++ b/locale/pt/hammer_cli_foreman_rh_cloud.po
@@ -3,47 +3,53 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Portuguese (https://app.transifex.com/foreman/teams/114/pt/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: pt\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
-"1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 100000"
+"0 == 0 ? 1 : 2;\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/pt_BR/hammer_cli_foreman_rh_cloud.po
+++ b/locale/pt_BR/hammer_cli_foreman_rh_cloud.po
@@ -6,49 +6,55 @@
 # Translators:
 # Amit Upadhye <aupadhye@redhat.com>, 2023
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Last-Translator: Amit Upadhye <aupadhye@redhat.com>, 2023\n"
-"Language-Team: Portuguese (Brazil) (https://app.transifex.com/foreman/"
-"teams/114/pt_BR/)\n"
+"Language-Team: Portuguese (Brazil) (https://app.transifex.com/foreman/teams/11"
+"4/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: pt_BR\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
-"1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 100000"
+"0 == 0 ? 1 : 2;\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
-msgstr "Identificação da tarefa"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
+msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr "Identificação da tarefa"
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/ro/hammer_cli_foreman_rh_cloud.po
+++ b/locale/ro/hammer_cli_foreman_rh_cloud.po
@@ -3,47 +3,53 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Romanian (https://app.transifex.com/foreman/teams/114/ro/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ro\n"
-"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?"
-"2:1));\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2"
+":1));\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/ro_RO/hammer_cli_foreman_rh_cloud.po
+++ b/locale/ro_RO/hammer_cli_foreman_rh_cloud.po
@@ -3,48 +3,54 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Language-Team: Romanian (Romania) (https://app.transifex.com/foreman/"
-"teams/114/ro_RO/)\n"
+"Language-Team: Romanian (Romania) (https://app.transifex.com/foreman/teams/114"
+"/ro_RO/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ro_RO\n"
-"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?"
-"2:1));\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2"
+":1));\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/ru/hammer_cli_foreman_rh_cloud.po
+++ b/locale/ru/hammer_cli_foreman_rh_cloud.po
@@ -3,48 +3,54 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Russian (https://app.transifex.com/foreman/teams/114/ru/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
-"%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<="
+"4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=1"
+"1 && n%100<=14)? 2 : 3);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/sl/hammer_cli_foreman_rh_cloud.po
+++ b/locale/sl/hammer_cli_foreman_rh_cloud.po
@@ -3,47 +3,53 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Slovenian (https://app.transifex.com/foreman/teams/114/sl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: sl\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
-"%100==4 ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%"
+"100==4 ? 2 : 3);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/sv_SE/hammer_cli_foreman_rh_cloud.po
+++ b/locale/sv_SE/hammer_cli_foreman_rh_cloud.po
@@ -3,47 +3,53 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Language-Team: Swedish (Sweden) (https://app.transifex.com/foreman/teams/114/"
-"sv_SE/)\n"
+"Language-Team: Swedish (Sweden) (https://app.transifex.com/foreman/teams/114/s"
+"v_SE/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: sv_SE\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/ta/hammer_cli_foreman_rh_cloud.po
+++ b/locale/ta/hammer_cli_foreman_rh_cloud.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Tamil (https://app.transifex.com/foreman/teams/114/ta/)\n"
 "MIME-Version: 1.0\n"
@@ -17,32 +15,40 @@ msgstr ""
 "Language: ta\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/ta_IN/hammer_cli_foreman_rh_cloud.po
+++ b/locale/ta_IN/hammer_cli_foreman_rh_cloud.po
@@ -3,47 +3,53 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Language-Team: Tamil (India) (https://app.transifex.com/foreman/teams/114/"
-"ta_IN/)\n"
+"Language-Team: Tamil (India) (https://app.transifex.com/foreman/teams/114/ta_I"
+"N/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ta_IN\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/te/hammer_cli_foreman_rh_cloud.po
+++ b/locale/te/hammer_cli_foreman_rh_cloud.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Telugu (https://app.transifex.com/foreman/teams/114/te/)\n"
 "MIME-Version: 1.0\n"
@@ -17,32 +15,40 @@ msgstr ""
 "Language: te\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/tr/hammer_cli_foreman_rh_cloud.po
+++ b/locale/tr/hammer_cli_foreman_rh_cloud.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Turkish (https://app.transifex.com/foreman/teams/114/tr/)\n"
 "MIME-Version: 1.0\n"
@@ -17,32 +15,40 @@ msgstr ""
 "Language: tr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/vi/hammer_cli_foreman_rh_cloud.po
+++ b/locale/vi/hammer_cli_foreman_rh_cloud.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Vietnamese (https://app.transifex.com/foreman/teams/114/vi/)\n"
 "MIME-Version: 1.0\n"
@@ -17,32 +15,40 @@ msgstr ""
 "Language: vi\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/vi_VN/hammer_cli_foreman_rh_cloud.po
+++ b/locale/vi_VN/hammer_cli_foreman_rh_cloud.po
@@ -3,47 +3,53 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Language-Team: Vietnamese (Viet Nam) (https://app.transifex.com/foreman/"
-"teams/114/vi_VN/)\n"
+"Language-Team: Vietnamese (Viet Nam) (https://app.transifex.com/foreman/teams/"
+"114/vi_VN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: vi_VN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/zh/hammer_cli_foreman_rh_cloud.po
+++ b/locale/zh/hammer_cli_foreman_rh_cloud.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
 "Language-Team: Chinese (https://app.transifex.com/foreman/teams/114/zh/)\n"
 "MIME-Version: 1.0\n"
@@ -17,32 +15,40 @@ msgstr ""
 "Language: zh\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""

--- a/locale/zh_CN/hammer_cli_foreman_rh_cloud.po
+++ b/locale/zh_CN/hammer_cli_foreman_rh_cloud.po
@@ -7,49 +7,55 @@
 # Bryan Kearney <bryan.kearney@gmail.com>, 2023
 # Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarden.nl>, 2024
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Last-Translator: Ewoud Kohl van Wijngaarden <ewoud"
-"+transifex@kohlvanwijngaarden.nl>, 2024\n"
-"Language-Team: Chinese (China) (https://app.transifex.com/foreman/teams/114/"
-"zh_CN/)\n"
+"Last-Translator: Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarde"
+"n.nl>, 2024\n"
+"Language-Team: Chinese (China) (https://app.transifex.com/foreman/teams/114/zh"
+"_CN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: zh_CN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "Cloud connector enable task started"
-msgstr "已启动 Cloud connector 启用任务"
+msgid "Duration: %sms"
+msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
-msgstr "启用云连接器失败，请检查服务器日志以了解更多信息"
+msgid "Message: %s"
+msgstr ""
 
-msgid "Task id"
-msgstr "任务 ID"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
+msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr "清单同步任务已成功启动"
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
 msgstr "启用云连接器失败，请检查服务器日志以了解更多信息"
+
+msgid "Task id"
+msgstr "任务 ID"
+
+msgid "Path to download report."
+msgstr ""
 
 msgid "Failed to download report"
 msgstr "下载报告失败。"
+
+msgid "Generate the report, but do not upload"
+msgstr ""
 
 msgid "Report generation started successfully"
 msgstr "生成报告成功启动"
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr "启动生成报告任务失败，请检查服务器日志以了解更多信息"

--- a/locale/zh_TW/hammer_cli_foreman_rh_cloud.po
+++ b/locale/zh_TW/hammer_cli_foreman_rh_cloud.po
@@ -3,47 +3,53 @@
 # This file is distributed under the same license as the hammer-cli-foreman-rh-cloud package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_rh_cloud 1.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-12 16:17+0000\n"
 "PO-Revision-Date: 2023-10-05 11:01+0000\n"
-"Language-Team: Chinese (Taiwan) (https://app.transifex.com/foreman/teams/114/"
-"zh_TW/)\n"
+"Language-Team: Chinese (Taiwan) (https://app.transifex.com/foreman/teams/114/z"
+"h_TW/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: zh_TW\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "Cloud connector enable task started"
+msgid "Duration: %sms"
 msgstr ""
 
-msgid ""
-"Failed to enable cloud connector, please check server logs for more "
-"information"
+msgid "Message: %s"
 msgstr ""
 
-msgid "Task id"
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
 msgstr ""
 
 msgid "Inventory sync task started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start inventory sync task, please check server logs for more "
-"information"
+"Failed to start inventory sync task, please check server logs for more information"
+msgstr ""
+
+msgid "Task id"
+msgstr ""
+
+msgid "Path to download report."
 msgstr ""
 
 msgid "Failed to download report"
+msgstr ""
+
+msgid "Generate the report, but do not upload"
 msgstr ""
 
 msgid "Report generation started successfully"
 msgstr ""
 
 msgid ""
-"Failed to start report generation task, please check server logs for more "
-"information."
+"Failed to start report generation task, please check server logs for more information."
 msgstr ""


### PR DESCRIPTION
Regenerate pot/po catalogs via gettext:find after removing hammer insights cloud-connector enable strings.

Separated translation changes from main PR https://github.com/theforeman/hammer-cli-foreman-rh-cloud/pull/20